### PR TITLE
Move `raui::renderer::material` to `raui::material`

### DIFF
--- a/raui-material/src/lib.rs
+++ b/raui-material/src/lib.rs
@@ -1,3 +1,5 @@
+//! Theme-able RAUI components
+
 pub mod component;
 pub mod theme;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,13 +379,12 @@ mod tests;
 #[doc(inline)]
 pub use raui_core as core;
 
+#[doc(inline)]
+#[cfg(feature = "material")]
+pub use raui_material as material;
+
 /// Renderer implementations
 pub mod renderer {
-    #[cfg(feature = "material")]
-    pub mod material {
-        pub use raui_material::*;
-    }
-
     #[cfg(feature = "binary")]
     pub mod binary {
         pub use raui_binary_renderer::*;


### PR DESCRIPTION
Just realized that `material` shouldn't be in `renderers`, I don't think.