### PR TITLE
Add CI Check To Ensure Up-to-Date README

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,0 +1,22 @@
+name: Check README
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # Make sure that the readme has been generated from the `lib.rs` docs
+  # and is not out-of-sync.
+  check-readme:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/msrd0/cargo-readme:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Copy README
+        run: cp README.md README.md.ref
+      - name: Generate README from lib.rs
+        run: cargo readme > README.md
+      - name: Diff Generated README and Copied README
+        run: diff README.md README.md.ref


### PR DESCRIPTION
This make sure that the README is in sync with the lib.rs documentation.

If you change the README accidentally instead of updating lib.rs and then using `cargo readme` CI will fail.