### PR TITLE
Allow Coord Mappings to Different Aspect Ratios

### DIFF
--- a/raui-core/src/layout/mod.rs
+++ b/raui-core/src/layout/mod.rs
@@ -181,7 +181,7 @@ impl Default for CoordsMappingScaling {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CoordsMapping {
     #[serde(default)]
-    scale: Scalar,
+    scale: Vec2,
     #[serde(default)]
     offset: Vec2,
     #[serde(default)]
@@ -199,7 +199,7 @@ impl Default for CoordsMapping {
 impl CoordsMapping {
     pub fn new(real_area: Rect) -> Self {
         Self {
-            scale: 1.0,
+            scale: 1.0.into(),
             offset: Vec2::default(),
             real_area,
             virtual_area: Rect {
@@ -218,13 +218,15 @@ impl CoordsMapping {
                 let vh = size.y;
                 let rw = real_area.width();
                 let rh = real_area.height();
-                let va = vw / vh;
-                let ra = rw / rh;
-                let scale = if va >= ra { rw / vw } else { rh / vh };
-                let w = vw * scale;
-                let h = vh * scale;
+                let scale_x = rw / vw;
+                let scale_y = rh / vh;
+                let w = vw * scale_x;
+                let h = vh * scale_y;
                 Self {
-                    scale,
+                    scale: Vec2 {
+                        x: scale_x,
+                        y: scale_y,
+                    },
                     offset: Vec2 {
                         x: (rw - w) * 0.5,
                         y: (rh - h) * 0.5,
@@ -244,7 +246,7 @@ impl CoordsMapping {
                 let scale = rw / vw;
                 let vh = rh / scale;
                 Self {
-                    scale,
+                    scale: scale.into(),
                     offset: Vec2::default(),
                     real_area,
                     virtual_area: Rect {
@@ -261,7 +263,7 @@ impl CoordsMapping {
                 let scale = rh / vh;
                 let vw = rw / scale;
                 Self {
-                    scale,
+                    scale: scale.into(),
                     offset: Vec2::default(),
                     real_area,
                     virtual_area: Rect {
@@ -287,7 +289,7 @@ impl CoordsMapping {
                 }
             }
             _ => Self {
-                scale: 1.0,
+                scale: 1.0.into(),
                 offset: Vec2::default(),
                 real_area,
                 virtual_area: Rect {
@@ -301,7 +303,7 @@ impl CoordsMapping {
     }
 
     #[inline]
-    pub fn scale(&self) -> Scalar {
+    pub fn scale(&self) -> Vec2 {
         self.scale
     }
 
@@ -318,36 +320,36 @@ impl CoordsMapping {
     #[inline]
     pub fn virtual_to_real_vec2(&self, coord: Vec2) -> Vec2 {
         Vec2 {
-            x: self.offset.x + (coord.x * self.scale),
-            y: self.offset.y + (coord.y * self.scale),
+            x: self.offset.x + (coord.x * self.scale.x),
+            y: self.offset.y + (coord.y * self.scale.y),
         }
     }
 
     #[inline]
     pub fn real_to_virtual_vec2(&self, coord: Vec2) -> Vec2 {
         Vec2 {
-            x: (coord.x - self.offset.x) / self.scale,
-            y: (coord.y - self.offset.y) / self.scale,
+            x: (coord.x - self.offset.x) / self.scale.x,
+            y: (coord.y - self.offset.y) / self.scale.y,
         }
     }
 
     #[inline]
     pub fn virtual_to_real_rect(&self, area: Rect) -> Rect {
         Rect {
-            left: self.offset.x + (area.left * self.scale),
-            right: self.offset.x + (area.right * self.scale),
-            top: self.offset.y + (area.top * self.scale),
-            bottom: self.offset.y + (area.bottom * self.scale),
+            left: self.offset.x + (area.left * self.scale.x),
+            right: self.offset.x + (area.right * self.scale.x),
+            top: self.offset.y + (area.top * self.scale.y),
+            bottom: self.offset.y + (area.bottom * self.scale.y),
         }
     }
 
     #[inline]
     pub fn real_to_virtual_rect(&self, area: Rect) -> Rect {
         Rect {
-            left: (area.left - self.offset.x) / self.scale,
-            right: (area.right - self.offset.x) / self.scale,
-            top: (area.top - self.offset.y) / self.scale,
-            bottom: (area.bottom - self.offset.y) / self.scale,
+            left: (area.left - self.offset.x) / self.scale.x,
+            right: (area.right - self.offset.x) / self.scale.x,
+            top: (area.top - self.offset.y) / self.scale.y,
+            bottom: (area.bottom - self.offset.y) / self.scale.y,
         }
     }
 }

--- a/raui-ggez-renderer/src/renderer.rs
+++ b/raui-ggez-renderer/src/renderer.rs
@@ -112,10 +112,10 @@ impl<'a> GgezRenderer<'a> {
                                 builder.raw(vertices, indices, None);
                             }
                             ImageBoxImageScaling::Frame(frame) => {
-                                let vl = frame.destination.left * scale;
-                                let vr = frame.destination.right * scale;
-                                let vt = frame.destination.top * scale;
-                                let vb = frame.destination.bottom * scale;
+                                let vl = frame.destination.left * scale.x;
+                                let vr = frame.destination.right * scale.x;
+                                let vt = frame.destination.top * scale.y;
+                                let vb = frame.destination.bottom * scale.y;
                                 let vertices = &[
                                     graphics::Vertex {
                                         pos: [rect.left, rect.top],
@@ -309,10 +309,10 @@ impl<'a> GgezRenderer<'a> {
                                     let ft = frame.source.top / resource.height() as Scalar;
                                     let fb =
                                         1.0 - (frame.source.bottom / resource.height() as Scalar);
-                                    let vl = frame.destination.left * scale;
-                                    let vr = frame.destination.right * scale;
-                                    let vt = frame.destination.top * scale;
-                                    let vb = frame.destination.bottom * scale;
+                                    let vl = frame.destination.left * scale.x;
+                                    let vr = frame.destination.right * scale.x;
+                                    let vt = frame.destination.top * scale.y;
+                                    let vb = frame.destination.bottom * scale.y;
                                     let vertices = &[
                                         graphics::Vertex {
                                             pos: [rect.left, rect.top],
@@ -452,7 +452,10 @@ impl<'a> GgezRenderer<'a> {
                                 unit.color.a,
                             ),
                         ));
-                        text.set_font(*resource, Scale::uniform(unit.font.size * mapping.scale()));
+                        text.set_font(
+                            *resource,
+                            Scale::uniform(unit.font.size * mapping.scale().x),
+                        );
                         text.set_bounds(
                             [rect.width(), rect.height()],
                             match unit.horizontal_align {

--- a/raui-tesselate-renderer/src/renderer.rs
+++ b/raui-tesselate-renderer/src/renderer.rs
@@ -182,7 +182,7 @@ where
     fn produce_color_triangles(
         &self,
         size: Vec2,
-        scale: Scalar,
+        scale: Vec2,
         data: &ImageBoxColor,
         result: &mut Tesselation,
     ) {
@@ -253,10 +253,10 @@ where
             }
             ImageBoxImageScaling::Frame(frame) => {
                 let mut d = frame.destination;
-                d.left *= scale;
-                d.right *= scale;
-                d.top *= scale;
-                d.bottom *= scale;
+                d.left *= scale.x;
+                d.right *= scale.x;
+                d.top *= scale.y;
+                d.bottom *= scale.y;
                 if d.left + d.right > size.x {
                     let m = d.left + d.right;
                     d.left = size.x * d.left / m;
@@ -446,7 +446,7 @@ where
     fn produce_image_triangles(
         &self,
         rect: Rect,
-        scale: Scalar,
+        scale: Vec2,
         data: &ImageBoxImage,
         result: &mut Tesselation,
     ) {
@@ -543,10 +543,10 @@ where
                     })
                     .unwrap_or((Vec2 { x: 1.0, y: 1.0 }, Vec2 { x: 1.0, y: 1.0 }));
                 let mut d = frame.destination;
-                d.left *= scale;
-                d.right *= scale;
-                d.top *= scale;
-                d.bottom *= scale;
+                d.left *= scale.x;
+                d.right *= scale.x;
+                d.top *= scale.y;
+                d.bottom *= scale.y;
                 if frame.frame_keep_aspect_ratio {
                     d.left = (frame.source.left * rect.height()) / source_size.y;
                     d.right = (frame.source.right * rect.height()) / source_size.y;

--- a/raui-tetra-renderer/src/renderer.rs
+++ b/raui-tetra-renderer/src/renderer.rs
@@ -273,7 +273,7 @@ where
                             .unwrap_or(h);
                         let scale = if height > 0.0 {
                             let f = (h / height).min(1.0);
-                            Vec2::new(scale / font_scale, scale * f / font_scale)
+                            Vec2::new(scale.x / font_scale, scale.y * f / font_scale)
                         } else {
                             Vec2::default()
                         };


### PR DESCRIPTION
In Bevy retro I have an option to use non-square pixels, which puts the virtual screen coords in a different aspect ratio from real screen coords. This is a simple fix that just uses a `Vec2` instead of a `Scalar` for the `scale` of the `CoordsMapping`. 