### PR TITLE
Fix Text Input When TextInputMode is Not Specified

### DIFF
--- a/raui-core/src/widget/component/interactive/input_field.rs
+++ b/raui-core/src/widget/component/interactive/input_field.rs
@@ -134,9 +134,11 @@ pub fn use_text_input(context: &mut WidgetContext) {
 
     context.life_cycle.mount(|context| {
         let mut data = context.props.read_cloned_or_default::<TextInputProps>();
-        if let Ok(mode) = context.props.read::<TextInputMode>() {
-            data.text = mode.process(&data.text).unwrap_or_default();
-        }
+        let mode = context
+            .props
+            .read::<TextInputMode>()
+            .unwrap_or(&TextInputMode::Text);
+        data.text = mode.process(&data.text).unwrap_or_default();
         data.focused = false;
         notify(
             &context,
@@ -167,12 +169,14 @@ pub fn use_text_input(context: &mut WidgetContext) {
                                             data.cursor_position.min(data.text.len());
                                         let old = data.text.to_owned();
                                         data.text.insert(data.cursor_position, *c);
-                                        if let Ok(mode) = context.props.read::<TextInputMode>() {
-                                            if mode.is_valid(&data.text) {
-                                                data.cursor_position += 1;
-                                            } else {
-                                                data.text = old;
-                                            }
+                                        let mode = context
+                                            .props
+                                            .read::<TextInputMode>()
+                                            .unwrap_or(&TextInputMode::Text);
+                                        if mode.is_valid(&data.text) {
+                                            data.cursor_position += 1;
+                                        } else {
+                                            data.text = old;
                                         }
                                     }
                                 }


### PR DESCRIPTION
Previously, when a TextInputMode prop was not added to a textfield it would start inserting text after the cursor instead of before. This caused the trouble run into by @temportalflux [here](https://github.com/RAUI-labs/raui/discussions/52#discussioncomment-891663) and was also manifesting in the `hello-world` demo app.